### PR TITLE
Srcset fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ In short, Wiki Graph Explorer turns linear Wikipedia browsing into an immersive,
 
 ## 🚀 Getting Started
 - **The link to the Chrome extension store will be coming soon**
+- **For manual installation: ![release page](https://github.com/Apanazar/WGE/releases/tag/WGE_Chrome)**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Wiki Graph Explorer (WGE)
 
 **Wikipedia link visualizer** — install it as a Chrome/Firefox extension and dive into any article’s web of connections.
-
+  
+![WGE](https://github.com/Apanazar/stuprum/blob/master/wge2.png)
 ---
 
 ## 🎯 Who It’s For & Why You’ll Love It
@@ -59,6 +60,3 @@ In short, Wiki Graph Explorer turns linear Wikipedia browsing into an immersive,
 
 ## 🚀 Getting Started
 - **The link to the Chrome extension store will be coming soon**
-
----
-![WGE](https://github.com/Apanazar/stuprum/blob/master/wge.png)

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -39,6 +39,9 @@ async function parseWikiArticle(url) {
   contentEl.querySelectorAll('img').forEach(img => {
     const src = img.getAttribute('src') || '';
     if (src.startsWith('//')) img.src = 'https:' + src;
+    if (img.srcset) {
+      img.srcset = img.srcset.replace('//', 'https://');
+    }
     img.style.maxWidth = '100%';
     img.style.height = 'auto';
   });


### PR DESCRIPTION
If image has srcset (e.g. on page https://en.wikipedia.org/w/index.php?title=Pet_door), browser try to display not from src, but from srcset.

This PR patches urls in srcset like it's done for src. 